### PR TITLE
Add JWT decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,11 @@ default = ["console_error_panic_hook"]
 wasm-bindgen-test = "0.3"
 
 [dependencies]
-wasm-bindgen = "0.2"
 base64 = "0.13"
+serde_json = "1.0"
+thiserror = "1.0"
 urlencoding = "2.1"
+wasm-bindgen = "0.2"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ use wasm_bindgen::prelude::*;
 use base64;
 use urlencoding;
 use std::str;
+use serde_json;
+use std::string::FromUtf8Error;
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
@@ -9,21 +11,31 @@ use std::str;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+#[derive(Debug, thiserror::Error)]
+enum Error {
+    #[error(transparent)]
+    DecodeError(#[from] base64::DecodeError),
+
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    FromUtf8Error(#[from] FromUtf8Error),
+
+    #[error("Invalid token")]
+    InvalidToken
+}
+
 #[wasm_bindgen]
 pub fn encode_base64(s: &str) -> String {
     base64::encode(s)
 }
 
 #[wasm_bindgen]
-pub fn decode_base64(s: &str) -> String {
-    let chars = match base64::decode(s) {
-        Ok(chars) => chars,
-        _ => vec!()
-    };
-    match str::from_utf8(&chars) {
-        Ok(s) => s.to_string(),
-        _ => String::from("")
-    }
+pub fn decode_base64(s: &str) -> Result<String, JsError> {
+    let decoded = base64::decode(s)?;
+    let converted = String::from_utf8(decoded)?;
+    Ok(converted.to_string())
 }
 
 #[wasm_bindgen]
@@ -32,9 +44,32 @@ pub fn encode_url(s: &str) -> String {
 }
 
 #[wasm_bindgen]
-pub fn decode_url(s: &str) -> String {
-    match urlencoding::decode(s) {
-        Ok(s) => s.into_owned(),
-        _ => String::from("")
-    }
+pub fn decode_url(s: &str) -> Result<String, JsError> {
+    let decoded_str = urlencoding::decode(s)?;
+    Ok(decoded_str.into_owned())
+}
+
+fn parse_jwt(s: &str) -> Result<[serde_json::Value; 2], Error> {
+    let mut i = s.splitn(3, '.');
+    let (header, payload) = match (i.next(), i.next(), i.next(), i.next()){
+        (Some(header), Some(payload), Some(_signature), None) => (header, payload),
+        _ => return Err(Error::InvalidToken)
+    };
+
+    let decoded_header = base64::decode_config(header, base64::URL_SAFE_NO_PAD)?;
+    let decoded_payload = base64::decode_config(payload, base64::URL_SAFE_NO_PAD)?;
+
+    let converted_header = String::from_utf8(decoded_header)?;
+    let converted_payload = String::from_utf8(decoded_payload)?;
+
+    let parsed_jwt_header = serde_json::from_str::<serde_json::Value>(&converted_header)?;
+    let parsed_jwt_payload = serde_json::from_str::<serde_json::Value>(&converted_payload)?;
+
+    Ok([parsed_jwt_header, parsed_jwt_payload])
+}
+
+#[wasm_bindgen]
+pub fn decode_jwt(s: &str) -> Result<String, JsError> {
+    let jwt = parse_jwt(s)?;
+    Ok(serde_json::to_string_pretty(&jwt).unwrap())
 }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -3,7 +3,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use wasm_bindgen_test::*;
+use wasm_bindgen::*;
 use mstools::*;
+use serde_json::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -12,7 +14,8 @@ fn test_encode_decode_base64() {
     let input = "1234";
     let encoded = encode_base64(&input);
     let decoded = decode_base64(&encoded);
-    assert_eq!(&input, &decoded);
+
+    assert_eq!(Ok(String::from(input)), decoded.map_err(|e| JsValue::from(e)));
     assert_eq!(encoded, String::from("MTIzNA=="));
 }
 
@@ -21,6 +24,16 @@ fn test_encode_decode_url() {
     let input = "http://www.example.com";
     let encoded = encode_url(&input);
     let decoded = decode_url(&encoded);
-    assert_eq!(&input, &decoded);
+    assert_eq!(Ok(String::from(input)), decoded.map_err(|e| JsValue::from(e)));
     assert_eq!(encoded, String::from("http%3A%2F%2Fwww.example.com"));
+}
+
+#[wasm_bindgen_test]
+fn test_decode_jwt() {
+    let jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    let expected_jwt = [json!({"alg":"HS256","typ":"JWT"}),
+                        json!({"sub":"1234567890","name":"John Doe","iat":1516239022})];
+    let expected_jwt_string = serde_json::to_string_pretty(&expected_jwt).unwrap();
+    let decoded_jwt_string = decode_jwt(&jwt).map_err(|e| JsValue::from(e)).unwrap();
+    assert_eq!(expected_jwt_string, decoded_jwt_string);
 }

--- a/www/src/assets/css/main.css
+++ b/www/src/assets/css/main.css
@@ -9,3 +9,7 @@
 .btn-blue {
     @apply bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded;
 }
+
+.btn-fuchsia {
+    @apply bg-fuchsia-500 hover:bg-fuchsia-700 text-white font-bold py-2 px-4 rounded;
+}

--- a/www/src/index.html
+++ b/www/src/index.html
@@ -24,7 +24,9 @@
                 <button type="button" class="btn-black" id="decode_base64">Decode base64</button>
                 <button type="button" class="btn-blue" id="encode_url">Encode URL</button>
                 <button type="button" class="btn-blue" id="decode_url">Decode URL</button>
+                <button type="button" class="btn-fuchsia" id="decode_jwt">Decode JWT</button>
             </div>
+            <div id="error" class="text-red-500" hidden></div>
         </main>
         <noscript>This page contains webassembly and javascript content, please enable javascript in your browser.</noscript>
         <script src="./bootstrap.js"></script>

--- a/www/src/index.js
+++ b/www/src/index.js
@@ -1,6 +1,7 @@
 import * as mstools from "wasm-mstools";
 
 const inputTextArea = document.getElementById("input");
+const errorText = document.getElementById("error");
 
 const buttons_mapping = {
   encode_base64: () => {
@@ -15,11 +16,28 @@ const buttons_mapping = {
   decode_url: () => {
     inputTextArea.value = mstools.decode_url(inputTextArea.value);
   },
+  decode_jwt: () => {
+    inputTextArea.value = mstools.decode_jwt(inputTextArea.value);
+  },
+};
+
+const show_error = (message) => {
+  errorText.hidden = false;
+  errorText.textContent = message;
+};
+
+const hide_error = () => {
+  errorText.hidden = true;
 };
 
 for (const [button_id, fn] of Object.entries(buttons_mapping)) {
   let button = document.getElementById(button_id);
   button.addEventListener("click", (event) => {
-    fn();
+    try {
+      hide_error();
+      fn();
+    } catch (error) {
+      show_error(error.message);
+    }
   });
 }


### PR DESCRIPTION
Decodes a JWT as an array of 2 elements, the header and the payload. 

`decode_jwt`returns a `Result<T, JsError>` which throws a JS exception in case an `Err` is returned.